### PR TITLE
Add build script and gitignore

### DIFF
--- a/.build.sh
+++ b/.build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -ex
+
+Dockerfile=$(cat << EOF
+FROM ubuntu:15.10
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get upgrade -yy
+RUN DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -yy \
+	make gcc g++ libsystemd-dev libc6-dev pkg-config
+RUN groupadd -g ${GROUPS} ${USER} && useradd -d ${HOME} -m -u ${UID} -g ${GROUPS} ${USER}
+USER ${USER}
+ENV HOME ${HOME}
+EOF
+)
+
+docker pull ubuntu:15.10
+docker build -t openbmc/phosphor-event - <<< "${Dockerfile}"
+
+gcc --version
+
+docker run --rm=true --user="${USER}" \
+ -w "${PWD}" -v "${HOME}":"${HOME}" openbmc/phosphor-event make

--- a/.build.sh
+++ b/.build.sh
@@ -4,7 +4,7 @@ set -ex
 
 Dockerfile=$(cat << EOF
 FROM ubuntu:15.10
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get upgrade -yy
+RUN DEBIAN_FRONTEND=noninteractive apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -yy \
 	make gcc g++ libsystemd-dev libc6-dev pkg-config
 RUN groupadd -g ${GROUPS} ${USER} && useradd -d ${HOME} -m -u ${UID} -g ${GROUPS} ${USER}

--- a/.build.sh
+++ b/.build.sh
@@ -20,3 +20,5 @@ gcc --version
 
 docker run --rm=true --user="${USER}" \
  -w "${PWD}" -v "${HOME}":"${HOME}" openbmc/phosphor-event make
+docker run --rm=true --user="${USER}" \
+ -w "${PWD}" -v "${HOME}":"${HOME}" openbmc/phosphor-event make check

--- a/.build.sh
+++ b/.build.sh
@@ -16,8 +16,9 @@ EOF
 docker pull ubuntu:15.10
 docker build -t openbmc/phosphor-event - <<< "${Dockerfile}"
 
-gcc --version
 
+docker run --rm=true --user="${USER}" \
+ -w "${PWD}" -v "${HOME}":"${HOME}" openbmc/phosphor-event gcc --version
 docker run --rm=true --user="${USER}" \
  -w "${PWD}" -v "${HOME}":"${HOME}" openbmc/phosphor-event make
 docker run --rm=true --user="${USER}" \

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.o
+*.swp
+event_messaged


### PR DESCRIPTION
This adds a build script for compiling the software under docker.
It will be used for continuous integration on our Jenkins instance,
and can be used by developers.

Signed-off-by: Joel Stanley joel@jms.id.au
