### PR TITLE
Add support for limiting the size of the event log DB

### DIFF
--- a/event_messaged.C
+++ b/event_messaged.C
@@ -1,6 +1,8 @@
 #include <iostream>
 #include "message.H"
 #include "event_messaged_sdbus.h"
+#include <string>
+#include <unistd.h>
 
 const char *path_to_messages = "/var/lib/obmc/events";
 
@@ -44,10 +46,34 @@ int load_existing_events(event_manager *em)
 	return 0;
 }
 
+
+void print_usage(void)
+{
+	cout << "[-s <x>] : Maximum bytes to use for event logger"  << endl;
+	return;
+}
+
+
 int main(int argc, char *argv[])
 {
-	int rc = 0;
-	event_manager em(path_to_messages);
+	unsigned long maxsize=0;
+	int rc, c;
+
+	while ((c = getopt (argc, argv, "s:")) != -1)
+		switch (c) {
+			case 's':
+				maxsize =  strtoul(optarg, NULL, 10);
+				break;
+			case 'h':
+			case '?':
+				print_usage();
+				return 1;
+		}
+
+
+	cout << maxsize <<endl;
+	event_manager em(path_to_messages, maxsize);
+
 
 	rc = build_bus(&em);
 	if (rc < 0) {

--- a/message.H
+++ b/message.H
@@ -41,9 +41,11 @@ class event_manager {
 	string   eventpath;
 	DIR      *dirp;
 	uint16_t logcount;
+	size_t   maxsize;
+	size_t   currentsize;
 
 public:
-	event_manager(string path);
+	event_manager(string path, size_t reqmaxsize);
 	~event_manager();
 
 	uint16_t next_log(void);
@@ -63,6 +65,7 @@ private:
 	bool is_file_a_log(string str);
 	uint16_t create_log_event(event_record_t *rec);
 	uint16_t new_log_id(void);
+	bool     is_logid_a_log(uint16_t logid);
 };
 #else
 typedef struct event_manager event_manager;


### PR DESCRIPTION
embedded systems only have so much space.  This feature enables the event deamon to
limit the number of bytes used for logs via an input parameter

Limit the DB to 1k...
    /usr/sbin/phosphor-eventd -s 1000

Without the parameter the db size is unlimited.

When the db hits the limit, the event is NOT logged to the db.  It is however
added (without debug data) to the syslog still AND an error message is posted
in the syslog...

```
 event logger reached maximum capacity, event not logged
```

Interfaces exist already to clear the entire db and individual events.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/phosphor-event/15)

<!-- Reviewable:end -->
