### PR TITLE
Create a possible limit to the number of logs recorded

### DIFF
--- a/event_messaged.C
+++ b/event_messaged.C
@@ -54,19 +54,23 @@ int load_existing_events(event_manager *em)
 void print_usage(void)
 {
 	cout << "[-s <x>] : Maximum bytes to use for event logger"  << endl;
+	cout << "[-t <x>] : Limit total number of logs (will ignore newer)"  << endl;	
 	return;
 }
 
 
 int main(int argc, char *argv[])
 {
-	unsigned long maxsize=0;
+	unsigned long maxsize=0, maxlogs=0;
 	int rc, c;
 
-	while ((c = getopt (argc, argv, "s:")) != -1)
+	while ((c = getopt (argc, argv, "s:t:")) != -1)
 		switch (c) {
 			case 's':
 				maxsize =  strtoul(optarg, NULL, 10);
+				break;
+			case 't':
+				maxlogs =  strtoul(optarg, NULL, 10);
 				break;
 			case 'h':
 			case '?':
@@ -76,7 +80,7 @@ int main(int argc, char *argv[])
 
 
 	cout << maxsize <<endl;
-	event_manager em(path_to_messages, maxsize);
+	event_manager em(path_to_messages, maxsize, maxlogs);
 
 
 	rc = build_bus(&em);

--- a/message.H
+++ b/message.H
@@ -41,11 +41,12 @@ class event_manager {
 	string   eventpath;
 	DIR      *dirp;
 	uint16_t logcount;
+	uint16_t maxlogs;
 	size_t   maxsize;
 	size_t   currentsize;
 
 public:
-	event_manager(string path, size_t reqmaxsize);
+	event_manager(string path, size_t reqmaxsize, uint16_t reqmaxlogs);
 	~event_manager();
 
 	uint16_t next_log(void);


### PR DESCRIPTION
https://github.com/openbmc/openbmc/issues/268

There was a technique that created over 1000 event logs.  This taxed
the REST interface a lot.  It caused connections to time out.  I am
adding a way to limit the number of physical logs irregardless of the
size.  Like the size limiter, logs are not deleted automatically.

That may actually be a debate (save new logs, delete old logs) vs
(delete new logs, save old logs).  I welcome the suggestions.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/phosphor-event/18)

<!-- Reviewable:end -->
