### PR TITLE
event log limit not considering preexisting logs

### DIFF
--- a/message.C
+++ b/message.C
@@ -42,7 +42,7 @@ event_manager::event_manager(string path, size_t reqmaxsize, uint16_t reqmaxlogs
 	logcount = 0;
 	maxsize = -1;
 	maxlogs = -1;
-	currentsize = 0;
+	currentsize = get_managed_size();
 
 	if (reqmaxsize)
 		maxsize = reqmaxsize;

--- a/test.C
+++ b/test.C
@@ -180,6 +180,20 @@ int main(int argc, char *argv[])
 	assert(j.log_count() == 0);
 	assert(j.create(&rec) == 7);
 
+	/* Create an abundence of logs, then restart with a limited set  */
+	/* You should not be able to create new logs until the log size  */
+	/* dips below the request number                                 */
+	setup();
+	event_manager k(eventspath, 600, 100);
+	build_event_record(&rec,"Testing Message1", "Info", "Association", "Test", p, 4);
+	assert(k.create(&rec) == 1);
+	assert(k.create(&rec) == 2);
+	/* Now we have consumed 150 bytes */
+	event_manager l(eventspath, 151, 100);
+	assert(l.create(&rec) == 0);
+	assert(l.remove(2) == 0);
+	assert(l.create(&rec) == 4);
+
 
 	return 0;
 }


### PR DESCRIPTION
Turns out the code that checks for event log size limitations forgot
to take in to account the total size of logs that already existed.  So
it would let you create the max size of new logs rather then new+old.

I fixed this by initializing the variable when the process starts.  I
also added a test case that catches the problem.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/phosphor-event/19)

<!-- Reviewable:end -->
